### PR TITLE
Feat/add tcp chat room protocol

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.black-formatter",
+  },
+  "python.formatting.provider": "none",
+  "editor.formatOnSave": true
+}

--- a/stage2/client.py
+++ b/stage2/client.py
@@ -1,49 +1,102 @@
-#client
+# client
 import socket
 import threading
 
+
 class ChatClient:
     def __init__(self):
-        self.server_address = '127.0.0.1'
+        self.server_address = "127.0.0.1"
         self.tcp_port = 12345
         self.udp_port = 12346
 
-    def initialize_tcp_connection(self, operation_code, room_name):
+    def initialize_tcp_connection(
+        self, room_name: str, operation_code: int, state: int, operation_payload: str
+    ) -> str:
+        # TCPソケットの作成
         tcp_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        # サーバーへ接続要求
         tcp_socket.connect((self.server_address, self.tcp_port))
-        tcp_socket.send(operation_code.encode())
-        tcp_socket.send(room_name.ljust(255, '\x00').encode())
 
+        # TODO: チャットルームプロトコル
+        # サーバの初期化(0): クライアントが新しいチャットルームを作成するリクエストを送信
+        # ペイロードには希望するユーザー名が含まれる。
+
+        # Chat_Room_Protocol
+        # Header(32): RoomNameSize(1) | Operation(1) | State(1) | OperationPayloadSize(29)
+        # Body: payload(user_name)
+        room_name_bits = room_name.encode()
+        operation_payload_bits = operation_payload.encode()
+
+        header = self.tcp_chat_room_protocol_header(
+            len(room_name_bits), operation_code, state, len(operation_payload_bits)
+        )
+
+        # ヘッダの送信
+        tcp_socket.send(header)
+
+        # ペイロード(user_name)の送信
+        tcp_socket.send(operation_payload_bits)
+
+        # トークンの受信
         token = tcp_socket.recv(4096).decode()
+
+        # ソケットを閉じる
         tcp_socket.close()
 
         return token
+
+    def tcp_chat_room_protocol_header(
+        self,
+        room_name_size: int,
+        operation_code: int,
+        state: int,
+        operation_payload_size: int,
+    ) -> bytes:
+        # Header(32bytes): RoomNameSize(1) | Operation(1) | State(1) | OperationPayloadSize(29)
+        # 1つの256ビットバイナリに結合
+        return (
+            room_name_size.to_bytes(1, "big")
+            + operation_code.to_bytes(1, "big")
+            + state.to_bytes(1, "big")
+            + operation_payload_size.to_bytes(29, "big")
+        )
 
     def udp_receive_messages(self, udp_socket):
         while True:
             message, addr = udp_socket.recvfrom(4096)
 
             # メッセージからルーム名を取り出す
-            room_name, user_message = message.decode().split('] ', 1)
+            room_name, user_message = message.decode().split("] ", 1)
             print(f"{room_name}] {addr} says: {user_message}")
 
     def start(self):
+        # UDPソケットの作成
         udp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        udp_socket.bind(('0.0.0.0', 0))
+        # バインド
+        udp_socket.bind(("0.0.0.0", 0))
 
-        username = input("Enter your username: ")
-        operation = input("Create (C) or Join (J) a chatroom? ")
+        # TODO: バリデーション
+        user_name = input("Enter your username: ")
+        operation_code = input("Create (1) or Join (2) a chatroom? ")
         room_name = input("Enter room name: ")
 
-        token = self.initialize_tcp_connection(operation, room_name)
+        if operation_code.isdecimal():
+            token = self.initialize_tcp_connection(
+                room_name, int(operation_code), 0, user_name
+            )
+        else:
+            raise Exception("引数には数字を指定してください")
 
         # トークンの取得後に受信用のスレッドを開始
         threading.Thread(target=self.udp_receive_messages, args=(udp_socket,)).start()
 
         while True:
             message = input("Your message: ")
-            full_message = f"{token}|[{username}]{message}"
-            udp_socket.sendto(full_message.encode(), (self.server_address, self.udp_port))
+            full_message = f"{token}|[{user_name}]{message}"
+            udp_socket.sendto(
+                full_message.encode(), (self.server_address, self.udp_port)
+            )
+
 
 if __name__ == "__main__":
     client = ChatClient()

--- a/stage2/client.py
+++ b/stage2/client.py
@@ -9,77 +9,6 @@ class ChatClient:
         self.tcp_port = 12345
         self.udp_port = 12346
 
-    def initialize_tcp_connection(
-        self, room_name: str, operation_code: int, state: int, operation_payload: str
-    ) -> str:
-        """
-        チャットルームプロトコル
-        サーバの初期化(0): クライアントが新しいチャットルームを作成するリクエストを送信
-        ペイロードには希望するユーザー名が含まれる
-
-        Chat_Room_Protocol
-        Header(32): RoomNameSize(1) | Operation(1) | State(1) | OperationPayloadSize(29)
-        Body: RoomName(RoomNameSize) | OperationPayload(room_name + user_name)(2^29)
-        """
-
-        room_name_bits = room_name.encode()
-        # 最初のRoomNameSizeバイトがルーム名、その後にOperationPayloadSizeバイトが続く
-        operation_payload_bits = room_name.encode() + operation_payload.encode()
-
-        header = self.tcp_chat_room_protocol_header(
-            len(room_name_bits), operation_code, state, len(operation_payload_bits)
-        )
-
-        # TCPソケットの作成
-        tcp_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-
-        try:
-            # サーバーへ接続要求
-            tcp_socket.connect((self.server_address, self.tcp_port))
-
-            # ヘッダの送信
-            tcp_socket.send(header)
-
-            # ペイロード(room_name + user_name)の送信
-            tcp_socket.send(operation_payload_bits)
-
-            """
-            チャットルームプロトコル
-            リクエストの応答(1): サーバからステータスコードを含むペイロードで即座に応答を受け取る
-            """
-            # ヘッダ受信
-            header = tcp_socket.recv(32)
-            # ヘッダから長さなどを抽出
-            room_name_size = int.from_bytes(header[:1], "big")
-            operation_code = int.from_bytes(header[1:2], "big")
-            state = int.from_bytes(header[2:3], "big")
-            operation_payload_size = int.from_bytes(header[3:33], "big")
-
-            room_name = tcp_socket.recv(room_name_size).decode()
-            status = tcp_socket.recv(operation_payload_size).decode()
-
-            if state == 1:
-                if status == "200":
-                    print("サーバから応答がありました")
-                else:
-                    print("サーバから応答がありませんでした。")
-
-            """
-            TODO: チャットルームプロトコル
-            リクエストの完了(2): サーバで生成されたユニークなトークンを受け取る。
-            チャットルームを作成する時このトークンはチャットルームのホストとして識別される。
-            チャットルームに参加する時も生成されたトークンを受け取るが、ホストではない。
-            トークンは最大255バイト。
-            """
-            # トークンの受信
-            token = tcp_socket.recv(4096).decode()
-            print(token)
-
-        finally:
-            tcp_socket.close()
-
-        return token
-
     def tcp_chat_room_protocol_header(
         self,
         room_name_size: int,
@@ -95,6 +24,94 @@ class ChatClient:
             + state.to_bytes(1, "big")
             + operation_payload_size.to_bytes(29, "big")
         )
+
+    def initialize_tcp_connection(
+        self, room_name: str, operation_code: int, state: int, operation_payload: str
+    ) -> str:
+        """
+        チャットルームプロトコル
+        サーバの初期化(0): クライアントが新しいチャットルームを作成するリクエストを送信
+        ペイロードには希望するユーザー名が含まれる
+
+        Chat_Room_Protocol
+        Header(32): RoomNameSize(1) | Operation(1) | State(1) | OperationPayloadSize(29)
+        Body: RoomName(RoomNameSize) | OperationPayload(room_name + user_name)(2^29)
+        """
+
+        # TCPソケットの作成
+        tcp_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+        try:
+            # サーバーへ接続要求
+            tcp_socket.connect((self.server_address, self.tcp_port))
+
+            room_name_bits = room_name.encode()
+            # 最初のRoomNameSizeバイトがルーム名、その後にOperationPayloadSizeバイトが続く
+            operation_payload_bits = room_name.encode() + operation_payload.encode()
+
+            header = self.tcp_chat_room_protocol_header(
+                len(room_name_bits), operation_code, state, len(operation_payload_bits)
+            )
+
+            # ヘッダの送信
+            tcp_socket.send(header)
+
+            # ペイロード(room_name + user_name)の送信
+            tcp_socket.send(operation_payload_bits)
+
+            # レスポンスの応答確認
+            isSuccess = self.isSuccess_response(tcp_socket)
+            if isSuccess:
+                print("サーバから応答がありました")
+                # トークンの受け取り
+                return self.receive_token(tcp_socket)
+
+            else:
+                print("サーバから応答がありませんでした。")
+                tcp_socket.close()
+                exit(1)
+
+        except Exception as e:
+            print(f"Error: {e} from initialize_tcp_connection")
+            tcp_socket.close()
+            exit(1)
+
+    def isSuccess_response(self, tcp_socket) -> bool:
+        """
+        チャットルームプロトコル
+        リクエストの応答(1): サーバからステータスコードを含むペイロードで即座に応答を受け取る
+        """
+        try:
+            # ヘッダ受信
+            header = tcp_socket.recv(32)
+            # ヘッダから長さなどを抽出
+            room_name_size = int.from_bytes(header[:1], "big")
+            operation_code = int.from_bytes(header[1:2], "big")
+            state = int.from_bytes(header[2:3], "big")
+            operation_payload_size = int.from_bytes(header[3:33], "big")
+
+            room_name = tcp_socket.recv(room_name_size).decode()
+            status = tcp_socket.recv(operation_payload_size).decode()
+            print(str(state) + status)
+
+            return state == 1 and status == "success"
+
+        except Exception as e:
+            print(f"Error: {e} from isSuccess_response")
+            exit(1)
+
+    def receive_token(self, tcp_socket) -> str:
+        try:
+            token = tcp_socket.recv(4096).decode()
+
+        except Exception as e:
+            print(f"Error: {e} from receive_token")
+            exit(1)
+
+        finally:
+            tcp_socket.close()
+
+        return token
 
     def udp_receive_messages(self, udp_socket):
         while True:

--- a/stage2/server.py
+++ b/stage2/server.py
@@ -4,6 +4,7 @@ import threading
 import random
 import string
 import time
+from typing import Tuple
 
 
 class ClientInfo:
@@ -145,7 +146,7 @@ class ChatServer:
             + operation_payload_size.to_bytes(29, "big")
         )
 
-    def tcp_server_init(self, conn, addr) -> tuple[str, int, int, str]:
+    def tcp_server_init(self, conn, addr) -> Tuple[str, int, int, str]:
         """
         Chat_Room_Protocol: サーバの初期化(0)
         Header(32): RoomNameSize(1) | Operation(1) | State(1) | OperationPayloadSize(29)

--- a/stage2/server.py
+++ b/stage2/server.py
@@ -1,12 +1,20 @@
-#server
+# server
 import socket
 import threading
 import random
 import string
 import time
 
+
 class ClientInfo:
-    def __init__(self, udp_addr=None, tcp_addr=None, access_token=None, username=None, is_host=False):
+    def __init__(
+        self,
+        udp_addr=None,
+        tcp_addr=None,
+        access_token=None,
+        username=None,
+        is_host=False,
+    ):
         self.udp_addr = udp_addr
         self.tcp_addr = tcp_addr
         self.access_token = access_token
@@ -15,18 +23,24 @@ class ClientInfo:
         self.last_message_time = time.time()
 
     def __repr__(self):
-        return (f"<ClientInfo(udp_addr={self.udp_addr}, tcp_addr={self.tcp_addr}, "
-                f"access_token={self.access_token}, username={self.username}, is_host={self.is_host})>")
+        return (
+            f"<ClientInfo(udp_addr={self.udp_addr}, tcp_addr={self.tcp_addr}, "
+            f"access_token={self.access_token}, username={self.username}, is_host={self.is_host})>"
+        )
+
+
 class ChatServer:
     def __init__(self):
-        self.chat_rooms = {}  
+        self.chat_rooms = {}
         self.tokens = {}
-        self.clients = {}  
+        self.clients = {}
         self.tcp_port = 12345
         self.udp_port = 12346
 
     def generate_token(self, size=10):
-        return ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(size))
+        return "".join(
+            random.choice(string.ascii_letters + string.digits) for _ in range(size)
+        )
 
     def send_system_message(self, udp_socket, message, addr):
         system_message = f"[System]{message}"
@@ -37,25 +51,31 @@ class ChatServer:
         while True:
             for room_name, client_infos in self.chat_rooms.items():
                 for client_info in client_infos:
-                    if time.time() - client_info.last_message_time > 30:  # 30 seconds inactivity
+                    if (
+                        time.time() - client_info.last_message_time > 30
+                    ):  # 30 seconds inactivity
                         removal_msg_for_host = f"[{room_name}] Server Message: Your room has been closed due to your inactivity."
-                        udp_socket.sendto(removal_msg_for_host.encode(), client_info.udp_addr)
+                        udp_socket.sendto(
+                            removal_msg_for_host.encode(), client_info.udp_addr
+                        )
                         client_infos.remove(client_info)
                         if client_info.is_host:
                             for ci in client_infos:
                                 removal_msg_for_client = f"[{room_name}] Server Message: Room has been closed due to host inactivity. You are also removed."
-                                udp_socket.sendto(removal_msg_for_client.encode(), ci.udp_addr)
-                            self.chat_rooms[room_name] = [] 
+                                udp_socket.sendto(
+                                    removal_msg_for_client.encode(), ci.udp_addr
+                                )
+                            self.chat_rooms[room_name] = []
                             break
-            time.sleep(10) 
+            time.sleep(10)
             print(self.chat_rooms)
 
     def tcp_handler(self, conn, addr):
         operation = conn.recv(1).decode()
-        room_name = conn.recv(255).decode().rstrip('\x00')
+        room_name = conn.recv(255).decode().rstrip("\x00")
 
         # チャットルーム作成
-        if operation == 'C':
+        if operation == "C":
             if room_name not in self.chat_rooms:
                 self.chat_rooms[room_name] = []
             token = self.generate_token()
@@ -65,7 +85,7 @@ class ChatServer:
             conn.send(token.encode())
 
         # チャットルーム参加
-        elif operation == 'J':
+        elif operation == "J":
             if room_name in self.chat_rooms:
                 token = self.generate_token()
                 self.tokens[token] = room_name
@@ -79,22 +99,22 @@ class ChatServer:
 
     def udp_handler(self):
         udp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        udp_socket.bind(('0.0.0.0', self.udp_port))
+        udp_socket.bind(("0.0.0.0", self.udp_port))
 
         while True:
             data, addr = udp_socket.recvfrom(4096)
-            token, username_message = data.decode().split('|', 1)
-            username, message = username_message.split(']', 1)
+            token, username_message = data.decode().split("|", 1)
+            username, message = username_message.split("]", 1)
 
             if token in self.tokens:
                 room_name = self.tokens[token]
                 self.clients[token].udp_addr = addr
                 self.clients[token].username = username
-                self.clients[token].last_message_time = time.time() 
+                self.clients[token].last_message_time = time.time()
 
                 # サーバー側でメッセージを表示
                 print(f"[{room_name} - {addr}] {username} says: {message}")
-          
+
                 # メッセージにルーム名とユーザー名を付け加える
                 room_message = f"[{room_name}]{username}] {message}"
 
@@ -106,14 +126,13 @@ class ChatServer:
                     if client_info.udp_addr != addr:
                         udp_socket.sendto(room_message.encode(), client_info.udp_addr)
 
-
     def start(self):
         tcp_server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        tcp_server.bind(('0.0.0.0', self.tcp_port))
+        tcp_server.bind(("0.0.0.0", self.tcp_port))
         tcp_server.listen(5)
 
         threading.Thread(target=self.udp_handler).start()
-        threading.Thread(target=self.check_for_inactive_clients).start() 
+        threading.Thread(target=self.check_for_inactive_clients).start()
 
         while True:
             conn, addr = tcp_server.accept()

--- a/stage2/server.py
+++ b/stage2/server.py
@@ -82,7 +82,7 @@ class ChatServer:
         リクエストの応答(1): サーバはステータスコードを含むペイロードで即座に応答する
         """
         state = 1
-        status = "200"
+        status = "success"
         room_name_bits = room_name.encode()
         operation_payload_bits = room_name.encode() + status.encode()
 


### PR DESCRIPTION
### 実装内容
- チャットルームの作成は「1」、参加は「2」で可能
- チャットルームプロトコル「サーバの初期化(0)」
- チャットルームプロトコル「リクエストの応答(1)」

**チャットルームプロトコル**
Header(32バイト): RoomNameSize(1) | Operation(1) | State(1) | OperationPayloadSize(29)
Body: RoomName(RoomNameSize) | OperationPayload(2^29)

### 不安なところ
- 関数の切り分け・エラーハンドリングの仕方
- チャットルームプロトコルの「リクエストの応答(1)」の実装の仕方がよく分からなかった。（トークンを返すだけではダメなのか。）

### その他
サーバの「レスポンスの完了(2)」は未実装
フローにコメントを追加した。細かすぎるので、適宜削除