### PR TITLE
Feat/udp add udp protocol

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.black-formatter",
+    "editor.formatOnSave": true
+  },
+}

--- a/stage2/client.py
+++ b/stage2/client.py
@@ -131,7 +131,7 @@ class ChatClient:
             room_name, user_message = message.decode().split("] ", 1)
             print(f"{room_name}] {addr} says: {user_message}")
 
-    def udp_send_messages(
+    def udp_send_message(
         self,
         udp_socket,
         udp_address: Tuple[str, int],
@@ -172,7 +172,13 @@ class ChatClient:
             room_name, int(operation_code), 0, user_name
         )
 
-        # TODO: トークン取得後にUDPへ接続
+        address = (self.server_address, self.udp_port)
+
+        # トークン取得後に自動的にUDPへ接続
+        first_message = (
+            f"{user_name}がルームを作成しました" if operation_code == 1 else f"{user_name}が参加しました"
+        )
+        self.udp_send_message(udp_socket, address, first_message, room_name, token)
 
         # トークンの取得後に受信用のスレッドを開始
         threading.Thread(target=self.udp_receive_messages, args=(udp_socket,)).start()
@@ -180,9 +186,7 @@ class ChatClient:
         while True:
             message = input("Your message: ")
 
-            address = (self.server_address, self.udp_port)
-
-            self.udp_send_messages(udp_socket, address, message, room_name, token)
+            self.udp_send_message(udp_socket, address, message, room_name, token)
 
 
 if __name__ == "__main__":

--- a/stage2/client.py
+++ b/stage2/client.py
@@ -40,7 +40,7 @@ class ChatClient:
         )
 
     def udp_chat_message_protocol_header(self, json_size: int) -> bytes:
-        return json_size.to_bytes(1, "big")
+        return json_size.to_bytes(2, "big")
 
     def initialize_tcp_connection(
         self, room_name: str, operation_code: int, state: int, operation_payload: str
@@ -169,10 +169,10 @@ class ChatClient:
 
         full_content_bits = json.dumps(full_content).encode()
 
-        # UDPヘッダの作成(1bytes)
+        # UDPヘッダの作成(2bytes)
         header = self.udp_chat_message_protocol_header(len(full_content_bits))
 
-        # UDPボディの作成(max 4095bytes)
+        # UDPボディの作成(max 4096bytes)
         body = full_content_bits
 
         udp_socket.sendto(header + body, udp_address)

--- a/stage2/client.py
+++ b/stage2/client.py
@@ -215,15 +215,6 @@ class ChatClient:
             self.udp_send_messages(
                 udp_socket, address, token, user_name, room_name, message
             )
-            # message_content = {
-            #     "token": token,
-            #     "username": user_name,
-            #     "message": message,
-            # }
-            # full_message = json.dumps(message_content)
-            # udp_socket.sendto(
-            #     full_message.encode(), (self.server_address, self.udp_port)
-            # )
 
 
 if __name__ == "__main__":

--- a/stage2/server.py
+++ b/stage2/server.py
@@ -208,7 +208,7 @@ class ChatServer:
                 print(f"[{room_name} - {addr}] {username} says: {message}")
 
                 # メッセージにルーム名とユーザー名を付け加える
-                room_message = f"[{room_name}]{username}] {message}"
+                room_message = f"[{room_name}][{username}] {message}"
 
                 # broadcast
                 current_client = self.clients[token]

--- a/stage2/server.py
+++ b/stage2/server.py
@@ -267,11 +267,11 @@ class ChatServer:
 
     def udp_receive_messages(self, udp_socket):
         data, addr = udp_socket.recvfrom(4096)
-        # ヘッダ(1bytes) + ボディ(max 4095bytes)
-        header = data[:1]
-        body = data[1:]
+        # ヘッダ(2bytes) + ボディ(max 4096bytes)
+        header = data[:2]
+        body = data[2:]
         # ヘッダから長さなど抽出
-        json_size = int.from_bytes(header[:1], "big")
+        json_size = int.from_bytes(header[:2], "big")
 
         message_dict = json.loads(body.decode())
         token = message_dict["token"]

--- a/stage2/server.py
+++ b/stage2/server.py
@@ -111,7 +111,9 @@ class ChatServer:
             token = self.generate_token()
             self.tokens[token] = room_name
             # クライアント情報の作成(ホスト権限アリ)
-            client_info = ClientInfo(tcp_addr=addr, access_token=token, is_host=True)
+            client_info = ClientInfo(
+                tcp_addr=addr, access_token=token, username=user_name, is_host=True
+            )
             # トークンにクライアント情報を割り当てる
             self.clients[token] = client_info
             conn.send(token.encode())
@@ -124,7 +126,9 @@ class ChatServer:
                 token = self.generate_token()
                 self.tokens[token] = room_name
                 # クライアント情報作成(ホスト権限ナシ)
-                client_info = ClientInfo(tcp_addr=addr, access_token=token)
+                client_info = ClientInfo(
+                    tcp_addr=addr, access_token=token, username=user_name
+                )
                 # トークンにユーザーを割り当てる
                 self.clients[token] = client_info
                 # クライアントにトークン送信
@@ -192,14 +196,12 @@ class ChatServer:
         udp_socket.bind(("0.0.0.0", self.udp_port))
 
         while True:
-            data, addr = udp_socket.recvfrom(4096)
-            token, username_message = data.decode().split("|", 1)
-            username, message = username_message.split("]", 1)
+            # クライアントからメッセージを受け取る
+            addr, room_name, token, message = self.udp_receive_message(udp_socket)
 
             if token in self.tokens:
-                room_name = self.tokens[token]
+                username = self.clients[token].username
                 self.clients[token].udp_addr = addr
-                self.clients[token].username = username
                 self.clients[token].last_message_time = time.time()
 
                 # サーバー側でメッセージを表示
@@ -208,6 +210,7 @@ class ChatServer:
                 # メッセージにルーム名とユーザー名を付け加える
                 room_message = f"[{room_name}]{username}] {message}"
 
+                # broadcast
                 current_client = self.clients[token]
                 if current_client not in self.chat_rooms[room_name]:
                     self.chat_rooms[room_name].append(current_client)
@@ -215,6 +218,21 @@ class ChatServer:
                 for client_info in self.chat_rooms[room_name]:
                     if client_info.udp_addr != addr:
                         udp_socket.sendto(room_message.encode(), client_info.udp_addr)
+
+    def udp_receive_message(self, udp_socket):
+        data, addr = udp_socket.recvfrom(4096)
+        # ヘッダ(2bytes) + ボディ(max 4094bytes)
+        header = data[:2]
+        body = data[2:]
+        # ヘッダから長さなど抽出
+        room_name_size = int.from_bytes(header[:1], "big")
+        token_size = int.from_bytes(header[1:2], "big")
+        # TODO: ここもう少し見やすく
+        room_name = body[:room_name_size].decode()
+        token = body[room_name_size : room_name_size + token_size].decode()
+        message = body[room_name_size + token_size :].decode()
+
+        return (addr, room_name, token, message)
 
     def start(self):
         # TCPソケットの作成


### PR DESCRIPTION
### 実装内容
- UDPのプロトコル作成
- TCP切断後に自動でUDPでサーバへメッセージを送り、サーバーにUDPのアドレスを登録させる。

**UDPプロトコル**
ヘッダー(2byte)：RoomNameSize（1）| TokenSize（1バイト）
ボディ(max 4094)：最初のRoomNameSizeバイトはルーム名、次のTokenSizeバイトはトークン文字列、その残りが実際のメッセージ
