### PR TITLE
クライアントのselfにTCPソケットなど各種プロパティを保持するようにした

### DIFF
--- a/stage2/client.py
+++ b/stage2/client.py
@@ -31,13 +31,6 @@ class ChatClient:
             s.close()
         return ip
 
-    """
-    TODO: サーバーでも同じプロトコルを使うので切り出して使いまわせるようにする
-    tcp_chat_room_protocol_header
-    tcp_send_data
-    tcp_receive_data
-    """
-
     def tcp_chat_room_protocol_header(
         self,
         room_name_size: int,
@@ -107,24 +100,6 @@ class ChatClient:
             """
 
             self.tcp_send_data(json_payload)
-            # # サーバーへ接続要求
-            # self.tcp_socket.connect((self.server_address, self.tcp_port))
-
-            # room_name_bits = self.room_name.encode()
-            # json_string_payload_bits = json_string_payload.encode()
-
-            # # ヘッダ作成
-            # header = self.tcp_chat_room_protocol_header(
-            #     len(room_name_bits),
-            #     self.operation_code,
-            #     self.state,
-            #     len(json_string_payload_bits),
-            # )
-            # # ボディ作成
-            # body = room_name_bits + json_string_payload_bits
-
-            # self.tcp_socket.send(header)
-            # self.tcp_socket.send(body)
 
         except Exception as e:
             print(f"Error: {e} from initialize_tcp_connection")
@@ -146,6 +121,9 @@ class ChatClient:
             """
             room_name, operation_code, state, json_payload = self.tcp_receive_data()
 
+            # stateの更新
+            self.state = state
+
             status = json_payload["status"]
             message = json_payload["message"]
 
@@ -165,12 +143,14 @@ class ChatClient:
         try:
             room_name, operation_code, state, json_payload = self.tcp_receive_data()
 
+            # stateの更新
+            self.state = state
+
             token = json_payload["token"]
 
         except Exception as e:
             print(f"Error: {e} from receive_token")
             exit(1)
-
         finally:
             self.tcp_socket.close()
 

--- a/stage2/client.py
+++ b/stage2/client.py
@@ -11,6 +11,14 @@ class ChatClient:
         self.server_address = self.get_ip_address()
         self.tcp_port = 12345
         self.udp_port = 12346
+        self.address = (self.server_address, self.udp_port)
+        self.tcp_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.udp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.token = ""
+        self.user_name = ""
+        self.room_name = ""
+        self.operation_code = 0  # Noneにしないための仮の数字
+        self.state = 0
 
     def get_ip_address(self):
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -22,6 +30,13 @@ class ChatClient:
         finally:
             s.close()
         return ip
+
+    """
+    TODO: サーバーでも同じプロトコルを使うので切り出して使いまわせるようにする
+    tcp_chat_room_protocol_header
+    tcp_send_data
+    tcp_receive_data
+    """
 
     def tcp_chat_room_protocol_header(
         self,
@@ -39,16 +54,46 @@ class ChatClient:
             + json_string_payload_size.to_bytes(29, "big")
         )
 
+    def tcp_send_data(self, json_payload: dict):
+        # サーバーへ接続要求
+        self.tcp_socket.connect((self.server_address, self.tcp_port))
+
+        room_name_bits = self.room_name.encode()
+        json_string_payload_bits = json.dumps(json_payload).encode()
+
+        # ヘッダ作成
+        header = self.tcp_chat_room_protocol_header(
+            len(room_name_bits),
+            self.operation_code,
+            self.state,
+            len(json_string_payload_bits),
+        )
+        # ボディ作成
+        body = room_name_bits + json_string_payload_bits
+
+        self.tcp_socket.send(header)
+        self.tcp_socket.send(body)
+
+    def tcp_receive_data(self) -> Tuple[str, int, int, dict]:
+        # ヘッダ受信
+        header = self.tcp_socket.recv(32)
+        # ヘッダから長さなどを抽出
+        room_name_size = int.from_bytes(header[:1], "big")
+        operation_code = int.from_bytes(header[1:2], "big")
+        state = int.from_bytes(header[2:3], "big")
+        json_payload_size = int.from_bytes(header[3:33], "big")
+        # ボディから抽出
+        room_name = self.tcp_socket.recv(room_name_size).decode()
+        json_payload = json.loads(self.tcp_socket.recv(json_payload_size).decode())
+
+        return (room_name, operation_code, state, json_payload)
+
     def udp_chat_message_protocol_header(self, json_size: int) -> bytes:
         return json_size.to_bytes(2, "big")
 
     def initialize_tcp_connection(
         self,
-        tcp_socket,
-        room_name: str,
-        operation_code: int,
-        state: int,
-        json_string_payload: str,
+        json_payload: dict,
     ) -> None:
         try:
             """
@@ -60,31 +105,33 @@ class ChatClient:
             Header(32): RoomNameSize(1) | Operation(1) | State(1) | OperationPayloadSize(29)
             Body: RoomName(RoomNameSize) | OperationPayload(user_name)(2^29)
             """
-            # サーバーへ接続要求
-            tcp_socket.connect((self.server_address, self.tcp_port))
 
-            room_name_bits = room_name.encode()
-            json_string_payload_bits = json_string_payload.encode()
+            self.tcp_send_data(json_payload)
+            # # サーバーへ接続要求
+            # self.tcp_socket.connect((self.server_address, self.tcp_port))
 
-            # ヘッダ作成
-            header = self.tcp_chat_room_protocol_header(
-                len(room_name_bits),
-                operation_code,
-                state,
-                len(json_string_payload_bits),
-            )
-            # ボディ作成
-            body = room_name_bits + json_string_payload_bits
+            # room_name_bits = self.room_name.encode()
+            # json_string_payload_bits = json_string_payload.encode()
 
-            tcp_socket.send(header)
-            tcp_socket.send(body)
+            # # ヘッダ作成
+            # header = self.tcp_chat_room_protocol_header(
+            #     len(room_name_bits),
+            #     self.operation_code,
+            #     self.state,
+            #     len(json_string_payload_bits),
+            # )
+            # # ボディ作成
+            # body = room_name_bits + json_string_payload_bits
+
+            # self.tcp_socket.send(header)
+            # self.tcp_socket.send(body)
 
         except Exception as e:
             print(f"Error: {e} from initialize_tcp_connection")
-            tcp_socket.close()
+            self.tcp_socket.close()
             exit(1)
 
-    def receive_request_result(self, tcp_socket) -> Tuple[str, str]:
+    def receive_request_result(self) -> None:
         try:
             """
             チャットルームプロトコル
@@ -97,44 +144,41 @@ class ChatClient:
                 failed: 何らかのエラー
             message: メッセージ
             """
-            # ヘッダ受信
-            header = tcp_socket.recv(32)
-            # ヘッダから長さなどを抽出
-            room_name_size = int.from_bytes(header[:1], "big")
-            operation_code = int.from_bytes(header[1:2], "big")  # 使ってない
-            state = int.from_bytes(header[2:3], "big")
-            operation_payload_size = int.from_bytes(header[3:33], "big")
+            room_name, operation_code, state, json_payload = self.tcp_receive_data()
 
-            room_name = tcp_socket.recv(room_name_size).decode()
-            operation_payload = json.loads(
-                tcp_socket.recv(operation_payload_size).decode()
-            )
-            status = operation_payload["status"]
-            message = operation_payload["message"]
+            status = json_payload["status"]
+            message = json_payload["message"]
 
-            return (status, message)
+            if status != "success":
+                print(message)
+                self.tcp_socket.close()
+                exit(1)
+
+            print(message)
 
         except Exception as e:
             print(f"Error: {e} from receive_request_result")
-            tcp_socket.close()
+            self.tcp_socket.close()
             exit(1)
 
-    def receive_token(self, tcp_socket) -> str:
+    def receive_token(self) -> str:
         try:
-            token = tcp_socket.recv(4096).decode()
+            room_name, operation_code, state, json_payload = self.tcp_receive_data()
+
+            token = json_payload["token"]
 
         except Exception as e:
             print(f"Error: {e} from receive_token")
             exit(1)
 
         finally:
-            tcp_socket.close()
+            self.tcp_socket.close()
 
         return token
 
-    def udp_receive_messages(self, udp_socket):
+    def udp_receive_messages(self):
         while True:
-            message, addr = udp_socket.recvfrom(4096)
+            message, addr = self.udp_socket.recvfrom(4096)
             try:
                 # メッセージからルーム名、ユーザー名、メッセージを取り出す
                 data = json.loads(message.decode())
@@ -151,17 +195,12 @@ class ChatClient:
 
     def udp_send_messages(
         self,
-        udp_socket,
-        udp_address: Tuple[str, int],
-        token: str,
-        user_name: str,
-        room_name: str,
         message: str,
     ):
         full_content = {
-            "token": token,
-            "user_name": user_name,
-            "room_name": room_name,
+            "token": self.token,
+            "user_name": self.user_name,
+            "room_name": self.room_name,
             "message": message,
         }
 
@@ -170,10 +209,10 @@ class ChatClient:
         # UDPヘッダの作成(2bytes)
         header = self.udp_chat_message_protocol_header(len(full_content_bits))
 
-        # UDPボディの作成(max 4096bytes)
+        # UDPボディの作成(max 4094bytes)
         body = full_content_bits
 
-        udp_socket.sendto(header + body, udp_address)
+        self.udp_socket.sendto(header + body, self.address)
 
     def prompt_and_validate_user_name(self) -> str:
         max_bytes_in_user_name = 255
@@ -213,56 +252,36 @@ class ChatClient:
                 return room_name
 
     def start(self):
-        # UDPソケットの作成
-        udp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        # バインド
-        udp_socket.bind(("0.0.0.0", 0))
+        self.user_name = self.prompt_and_validate_user_name()
+        self.operation_code = int(self.prompt_and_validate_operation_code())
+        self.room_name = self.prompt_and_validate_room_name()
 
-        user_name = self.prompt_and_validate_user_name()
-        operation_code = self.prompt_and_validate_operation_code()
-        room_name = self.prompt_and_validate_room_name()
-
-        # TCPソケットの作成
-        tcp_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-
-        json_payload = {"user_name": user_name}
+        json_payload = {"user_name": self.user_name}
 
         # TCP接続
-        self.initialize_tcp_connection(
-            tcp_socket, room_name, int(operation_code), 0, json.dumps(json_payload)
-        )
+        self.initialize_tcp_connection(json_payload)
+
         # レスポンスの応答
-        status, message = self.receive_request_result(tcp_socket)
-
-        if status != "success":
-            print(message)
-            tcp_socket.close()
-            exit(1)
-
-        print(message)
+        self.receive_request_result()
 
         # トークンの受け取り
-        token = self.receive_token(tcp_socket)
+        self.token = self.receive_token()
 
-        address = (self.server_address, self.udp_port)
-
-        # トークン取得後に自動的にUDPへ接続
+        # トークン取得後,自動的にUDPへ接続
+        self.udp_socket.bind(("0.0.0.0", 0))
         first_message = (
-            f"{user_name}がルームを作成しました" if operation_code == 1 else f"{user_name}が参加しました"
+            f"{self.user_name}がルームを作成しました"
+            if self.operation_code == 1
+            else f"{self.user_name}が参加しました"
         )
-        self.udp_send_messages(
-            udp_socket, address, token, user_name, room_name, first_message
-        )
+        self.udp_send_messages(first_message)
 
-        # トークンの取得後に受信用のスレッドを開始
-        threading.Thread(target=self.udp_receive_messages, args=(udp_socket,)).start()
+        # 受信用のスレッドを開始
+        threading.Thread(target=self.udp_receive_messages).start()
 
         while True:
             message = input("Your message: ")
-
-            self.udp_send_messages(
-                udp_socket, address, token, user_name, room_name, message
-            )
+            self.udp_send_messages(message)
 
 
 if __name__ == "__main__":

--- a/stage2/client.py
+++ b/stage2/client.py
@@ -98,7 +98,7 @@ class ChatClient:
             Header(32): RoomNameSize(1) | Operation(1) | State(1) | OperationPayloadSize(29)
             Body: RoomName(RoomNameSize) | OperationPayload(user_name)(2^29)
             """
-
+            self.state = 0
             self.tcp_send_data(json_payload)
 
         except Exception as e:
@@ -111,7 +111,8 @@ class ChatClient:
             """
             チャットルームプロトコル
             リクエストの応答(1): サーバからステータスコードを含むペイロードで即座に応答を受け取る
-            返り値: (stauts, message)
+            state: 正常なら1
+            payload: (stauts, message)
             status:
                 success: 部屋の作成に成功
                 room already exists: すでに同じ名前の部屋が存在する
@@ -121,8 +122,13 @@ class ChatClient:
             """
             room_name, operation_code, state, json_payload = self.tcp_receive_data()
 
-            # stateの更新
-            self.state = state
+            if state == 1:
+                # stateの更新
+                self.state = state
+            else:
+                print("正常にサーバが応答しませんでした")
+                self.tcp_socket.close()
+                exit(1)
 
             status = json_payload["status"]
             message = json_payload["message"]
@@ -143,8 +149,13 @@ class ChatClient:
         try:
             room_name, operation_code, state, json_payload = self.tcp_receive_data()
 
-            # stateの更新
-            self.state = state
+            if state == 2:
+                # stateの更新
+                self.state = state
+            else:
+                print("正常にサーバが応答しませんでした")
+                self.tcp_socket.close()
+                exit(1)
 
             token = json_payload["token"]
 

--- a/stage2/server.py
+++ b/stage2/server.py
@@ -194,7 +194,7 @@ class ChatServer:
             このトークンはクライアントをチャットルームのホストとして識別する。トークンは最大255バイト。
             TODO: 部屋の作成・参加を関数化
             """
-            if status == "success":
+            if status == "success" and state == 2:
                 # トークンを生成
                 token = self.generate_token()
                 # チャットルーム作成
@@ -224,8 +224,6 @@ class ChatServer:
                         # トークンにユーザーを割り当てる
                         self.clients[token] = client_info
 
-                # stateの更新
-                state = 2
                 json_payload = {"token": token}
                 self.send_token(conn, room_name, operation_code, state, json_payload)
 
@@ -282,11 +280,12 @@ class ChatServer:
             message = "何らかのエラーが発生しました"
             print(message)
 
-        state = 1
         json_payload = {"status": status, "message": message}
 
         self.tcp_send_data(conn, room_name, operation_code, state, json_payload)
 
+        # stateの更新
+        state = 2
         return (status, state)
 
     def send_token(self, conn, room_name, operation_code, state, json_payload):

--- a/stage2/server.py
+++ b/stage2/server.py
@@ -282,7 +282,7 @@ class ChatServer:
             message = "何らかのエラーが発生しました"
             print(message)
 
-        state = 2
+        state = 1
         json_payload = {"status": status, "message": message}
 
         self.tcp_send_data(conn, room_name, operation_code, state, json_payload)


### PR DESCRIPTION
### 実装内容
- ChatClientのselfに各プロパティを追加し、メソッドの引数を減らした。
- TCPプロトコルに沿って、送受信のメソッドを切り出した。
  - tcp_send_dataメソッド
  - tcp_receive_dataメソッド
- トークンの送受信もTCPプロトコルで行うようにした。